### PR TITLE
refactor(workspace): add workspace ID support across server and tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,8 @@ Below is a configuration example based on Cline, with different configurations f
       "command": "{path}/tapd-mcp-server",
       "env": {
         "TAPD_USERNAME": "<YOUR_USERNAME>",
-        "TAPD_PASSWORD": "<YOUR_PASSWORD>"
+        "TAPD_PASSWORD": "<YOUR_PASSWORD>",
+        "TAPD_WORKSPACE_ID": "<YOUR_WORKSPACE_ID>"
       }
     }
   }
@@ -55,7 +56,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	srv, err := mcp.NewServer(client)
+	workspaceID := 123456 // replace with your workspace ID
+
+	srv, err := mcp.NewServer(workspaceID, client)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/tapd-mcp-server/main.go
+++ b/cmd/tapd-mcp-server/main.go
@@ -1,25 +1,33 @@
 package main
 
 import (
+	"fmt"
 	"log"
 	"os"
+	"strconv"
 
 	"github.com/go-tapd/mcp"
 	"github.com/go-tapd/tapd"
 )
 
 func init() {
-	requiredEnvs("TAPD_USERNAME", "TAPD_PASSWORD")
+	requiredEnvs("TAPD_USERNAME", "TAPD_PASSWORD", "TAPD_WORKSPACE_ID")
 }
 
 func main() {
 	var (
-		username = os.Getenv("TAPD_USERNAME")
-		password = os.Getenv("TAPD_PASSWORD")
+		username  = os.Getenv("TAPD_USERNAME")
+		password  = os.Getenv("TAPD_PASSWORD")
+		workspace = os.Getenv("TAPD_WORKSPACE_ID")
 	)
 
-	if username == "" || password == "" {
-		log.Fatal("missing TAPD_USERNAME or TAPD_PASSWORD")
+	if username == "" || password == "" || workspace == "" {
+		log.Fatal("missing TAPD_USERNAME, TAPD_PASSWORD or TAPD_WORKSPACE_ID")
+	}
+
+	workspaceID, err := convertToInt(workspace)
+	if err != nil {
+		log.Fatalf("invalid TAPD_WORKSPACE_ID: %s", err)
 	}
 
 	client, err := tapd.NewClient(username, password)
@@ -27,7 +35,7 @@ func main() {
 		log.Fatal(err)
 	}
 
-	srv, err := mcp.NewServer(client)
+	srv, err := mcp.NewServer(workspaceID, client)
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -47,4 +55,12 @@ func requiredEnvs(keys ...string) {
 	if len(missing) > 0 {
 		log.Fatalf("missing required env vars: %v", missing)
 	}
+}
+
+func convertToInt(s string) (int, error) {
+	i, err := strconv.Atoi(s)
+	if err != nil {
+		return 0, fmt.Errorf("invalid int: %s", s)
+	}
+	return i, nil
 }

--- a/examples/sse/main.go
+++ b/examples/sse/main.go
@@ -14,7 +14,9 @@ func main() {
 		log.Fatal(err)
 	}
 
-	srv, err := mcp.NewServer(client)
+	workspaceID := 123456 // replace with your workspace ID
+
+	srv, err := mcp.NewServer(workspaceID, client)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/internal/tools/user/roles/tool.go
+++ b/internal/tools/user/roles/tool.go
@@ -3,8 +3,6 @@ package roles
 import (
 	"context"
 	"encoding/json"
-	"fmt"
-	"strconv"
 
 	"github.com/go-tapd/mcp/internal/tools"
 	"github.com/go-tapd/tapd"
@@ -12,21 +10,19 @@ import (
 )
 
 type Tool struct {
-	client *tapd.Client
-	tool   mcp.Tool
+	workspaceID int
+	client      *tapd.Client
+	tool        mcp.Tool
 }
 
 var _ tools.Tool = (*Tool)(nil)
 
-func NewTool(client *tapd.Client) *Tool {
+func NewTool(workspaceID int, client *tapd.Client) *Tool {
 	return &Tool{
-		client: client,
+		workspaceID: workspaceID,
+		client:      client,
 		tool: mcp.NewTool("get_user_roles",
 			mcp.WithDescription("获取项目角色ID对照关系"),
-			mcp.WithString("workspace_id", // todo: 调整为int类型？
-				mcp.Required(),
-				mcp.Description("项目ID"),
-			),
 		),
 	}
 }
@@ -36,21 +32,9 @@ func (t *Tool) Tool() mcp.Tool {
 }
 
 func (t *Tool) Run(ctx context.Context, request mcp.CallToolRequest) (*mcp.CallToolResult, error) {
-	workspaceID, ok := request.Params.Arguments["workspace_id"]
-	if !ok {
-		return nil, fmt.Errorf("workspace_id is required")
-	}
-	workspaceIDString, ok := workspaceID.(string)
-	if !ok {
-		return nil, fmt.Errorf("workspace_id must be a string")
-	}
-	workspaceIDInt, err := strconv.Atoi(workspaceIDString)
-	if err != nil {
-		return nil, err
-	}
 
 	roles, _, err := t.client.UserService.GetRoles(ctx, &tapd.GetRolesRequest{
-		WorkspaceID: tapd.Ptr(workspaceIDInt),
+		WorkspaceID: tapd.Ptr(t.workspaceID),
 	})
 	if err != nil {
 		return nil, err

--- a/server.go
+++ b/server.go
@@ -12,21 +12,23 @@ import (
 )
 
 type Server struct {
-	mcpServer  *server.MCPServer
-	tapdClient *tapd.Client
+	workspaceID int
+	mcpServer   *server.MCPServer
+	tapdClient  *tapd.Client
 }
 
 var _ http.Handler = (*Server)(nil)
 
-func NewServer(client *tapd.Client, opts ...Option) (*Server, error) {
+func NewServer(workspaceID int, client *tapd.Client, opts ...Option) (*Server, error) {
 	o, err := newOptions(opts...)
 	if err != nil {
 		return nil, err
 	}
 
 	srv := &Server{
-		tapdClient: client,
-		mcpServer:  server.NewMCPServer(o.name, Version()),
+		workspaceID: workspaceID,
+		tapdClient:  client,
+		mcpServer:   server.NewMCPServer(o.name, Version()),
 	}
 
 	srv.registerTools()
@@ -37,7 +39,7 @@ func NewServer(client *tapd.Client, opts ...Option) (*Server, error) {
 func (s *Server) registerTools() {
 	tools.RegisterTools(s.mcpServer,
 		greetings.NewTool(),
-		roles.NewTool(s.tapdClient),
+		roles.NewTool(s.workspaceID, s.tapdClient),
 	)
 }
 


### PR DESCRIPTION
The changes introduce workspace ID as a required parameter throughout the application:
- Added TAPD_WORKSPACE_ID as required environment variable
- Modified server initialization to accept workspace ID
- Updated tool implementations to use workspace ID from server context
- Adjusted examples and README to reflect workspace ID requirement
- Added validation for workspace ID conversion from string to int

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a workspace ID configuration option to allow users to specify their workspace identifier along with existing credentials.
- **Chores**
	- Enhanced startup validation to ensure all necessary configuration values are provided and are in the proper format, with improved error messaging for any issues encountered during initialization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->